### PR TITLE
fix(SQL): using parameterized queries to prevent SQL Injection

### DIFF
--- a/app/utils/config_definitions/utils.py
+++ b/app/utils/config_definitions/utils.py
@@ -51,20 +51,22 @@ def c_config_definition(
 
     validate_config_creation(json_schema, primary_key, secondary_indexes)
 
-    internal_query = internal_c_definition_query(
+    internal_query, internal_params = internal_c_definition_query(
         config_type_key, json_schema, primary_key, secondary_indexes
     )
-    data_store._execute_query(internal_query)
+    data_store._execute_query(internal_query, internal_params)
 
-    creation_query = c_config_definition_query(config_type_key, primary_key)
-    data_store._execute_query(creation_query)
+    creation_query, creation_params = c_config_definition_query(
+        config_type_key, primary_key
+    )
+    data_store._execute_query(creation_query, creation_params)
 
     for index in secondary_indexes:
-        index_query = c_index_query(config_type_key, index)
-        data_store._execute_query(index_query)
+        index_query, index_params = c_index_query(config_type_key, index)
+        data_store._execute_query(index_query, index_params)
 
-    index_query = c_index_query(config_type_key, primary_key)
-    data_store._execute_query(index_query)
+    index_query, index_params = c_index_query(config_type_key, primary_key)
+    data_store._execute_query(index_query, index_params)
 
     return None
 
@@ -82,8 +84,8 @@ def r_config_definition(config_type_key: str):
         The configuration definition.
     """
 
-    query = r_config_definition_query(config_type_key)
-    result = data_store._execute_query(query, mode="retrieve")
+    query, params = r_config_definition_query(config_type_key)
+    result = data_store._execute_query(query, params=params, mode="retrieve")
 
     if len(result) == 0 or result is None:
         raise Exception("Configuration definition not found.")
@@ -110,23 +112,25 @@ def u_config_definition(config_type_key: str, secondary_indexes: list):
 
     validate_config_update(json_schema, secondary_indexes)
 
-    internal_query = internal_u_definition_query(config_type_key, secondary_indexes)
-    data_store._execute_query(internal_query)
+    internal_query, internal_params = internal_u_definition_query(
+        config_type_key, secondary_indexes
+    )
+    data_store._execute_query(internal_query, internal_params)
 
-    list_query = l_index_query(config_type_key)
+    list_query, list_params = l_index_query(config_type_key)
 
-    result = data_store._execute_query(list_query, mode="retrieve")
+    result = data_store._execute_query(list_query, params=list_params, mode="retrieve")
     existing_indexes = [index["indexname"] for index in result]
 
     for index in secondary_indexes:
         if index not in existing_indexes:
-            index_query = c_index_query(config_type_key, index)
-            data_store._execute_query(index_query)
+            index_query, index_params = c_index_query(config_type_key, index)
+            data_store._execute_query(index_query, index_params)
 
     for index in existing_indexes:
         if index not in secondary_indexes:
-            index_query = d_index_query(config_type_key, index)
-            data_store._execute_query(index_query)
+            index_query, index_params = d_index_query(config_type_key, index)
+            data_store._execute_query(index_query, index_params)
 
     return None
 
@@ -142,11 +146,11 @@ def d_config_definition(config_type_key: str):
     -- Returns
     None
     """
-    internal_query = internal_d_definition_query(config_type_key)
-    data_store._execute_query(internal_query)
+    internal_query, internal_params = internal_d_definition_query(config_type_key)
+    data_store._execute_query(internal_query, internal_params)
 
-    delete_query = d_config_definition_query(config_type_key)
-    data_store._execute_query(delete_query)
+    delete_query, delete_params = d_config_definition_query(config_type_key)
+    data_store._execute_query(delete_query, delete_params)
 
     return None
 
@@ -165,7 +169,7 @@ def l_config_definition(page: int, page_size: int):
     list
         The configuration definitions.
     """
-    query = l_config_definition_query(page, page_size)
-    result = data_store._execute_query(query, mode="retrieve")
+    query, params = l_config_definition_query(page, page_size)
+    result = data_store._execute_query(query, params=params, mode="retrieve")
 
     return result

--- a/app/utils/data/data_source.py
+++ b/app/utils/data/data_source.py
@@ -30,7 +30,7 @@ class DataStore:
     def __del__(self):
         self._close_connection()
 
-    def _execute_query(self, query, mode="submit"):
+    def _execute_query(self, query, params=(), mode="submit"):
         """
         Execute a SQL query using a cursor, with error handling and cleanup.
         """
@@ -39,7 +39,7 @@ class DataStore:
             raise RuntimeError("No database connection defined!")
         try:
             cursor = self.connection.cursor()
-            cursor.execute(query)
+            cursor.execute(query, params)
             if mode == "retrieve":
                 response = [
                     dict(zip([column[0] for column in cursor.description], row))

--- a/tests/unit_tests/test_config_definition.py
+++ b/tests/unit_tests/test_config_definition.py
@@ -58,19 +58,21 @@ class TestConfigDefinitionUnit:
         secondary_index = "date"
         secondary_indexes_list = [secondary_index]
 
-        creation_query = c_config_definition_query(config_key, primary_key_field)
-        internal_query = internal_c_definition_query(
+        creation_query, creation_params = c_config_definition_query(
+            config_key, primary_key_field
+        )
+        internal_query, internal_params = internal_c_definition_query(
             config_key, schema, primary_key_field, secondary_indexes_list
         )
-        index_query = c_index_query(config_key, secondary_index)
+        index_query, index_params = c_index_query(config_key, secondary_index)
 
         c_config_definition(
             config_key, schema, primary_key_field, secondary_indexes_list
         )
 
-        mock_execute_query.assert_any_call(creation_query)
-        mock_execute_query.assert_any_call(internal_query)
-        mock_execute_query.assert_any_call(index_query)
+        mock_execute_query.assert_any_call(creation_query, creation_params)
+        mock_execute_query.assert_any_call(internal_query, internal_params)
+        mock_execute_query.assert_any_call(index_query, index_params)
 
     @patch.object(
         DataStore,
@@ -86,10 +88,12 @@ class TestConfigDefinitionUnit:
 
         config_key = "sample_config"
 
-        internal_query = r_config_definition_query(config_key)
+        internal_query, internal_params = r_config_definition_query(config_key)
         r_config_definition(config_key)
 
-        mock_execute_query.assert_called_once_with(internal_query, mode="retrieve")
+        mock_execute_query.assert_called_once_with(
+            internal_query, params=internal_params, mode="retrieve"
+        )
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
     @patch.object(DataStore, "_execute_query")
@@ -114,13 +118,19 @@ class TestConfigDefinitionUnit:
             "secondary_indexes": ["date"],
         }
 
-        internal_query = internal_u_definition_query(config_key, updated_indexes_list)
-        index_list_query = l_index_query(config_key)
-        index_creation_query = c_index_query(config_key, "name")
-        index_deletion_query = d_index_query(config_key, "date")
+        internal_query, internal_params = internal_u_definition_query(
+            config_key, updated_indexes_list
+        )
+        index_list_query, index_list_params = l_index_query(config_key)
+        index_creation_query, index_creation_params = c_index_query(config_key, "name")
+        index_deletion_query, index_deletion_params = d_index_query(config_key, "date")
 
-        def side_effect(query, mode=None):
-            if query == index_list_query and mode == "retrieve":
+        def side_effect(query, params=None, mode=None):
+            if (
+                query == index_list_query
+                and params == index_list_params
+                and mode == "retrieve"
+            ):
                 return [{"indexname": "date"}]
             return []
 
@@ -128,12 +138,14 @@ class TestConfigDefinitionUnit:
 
         u_config_definition(config_key, updated_indexes_list)
 
-        mock_execute_query.assert_any_call(index_list_query, mode="retrieve")
-        mock_execute_query.assert_any_call(index_creation_query)
-        mock_execute_query.assert_any_call(index_deletion_query)
+        mock_execute_query.assert_any_call(
+            index_list_query, params=index_list_params, mode="retrieve"
+        )
+        mock_execute_query.assert_any_call(index_creation_query, index_creation_params)
+        mock_execute_query.assert_any_call(index_deletion_query, index_deletion_params)
 
         mock_r_config_definition.assert_called_once_with(config_key)
-        mock_execute_query.assert_any_call(internal_query)
+        mock_execute_query.assert_any_call(internal_query, internal_params)
 
     @patch.object(DataStore, "_execute_query")
     def test_delete_config_definition(self, mock_execute_query):
@@ -145,12 +157,12 @@ class TestConfigDefinitionUnit:
 
         config_key = "sample_config"
 
-        delete_query = d_config_definition_query(config_key)
-        internal_query = internal_d_definition_query(config_key)
+        delete_query, delete_params = d_config_definition_query(config_key)
+        internal_query, internal_params = internal_d_definition_query(config_key)
         d_config_definition(config_key)
 
-        mock_execute_query.assert_any_call(delete_query)
-        mock_execute_query.assert_any_call(internal_query)
+        mock_execute_query.assert_any_call(delete_query, delete_params)
+        mock_execute_query.assert_any_call(internal_query, internal_params)
 
     @patch.object(
         DataStore, "_execute_query", return_value=[{"config_key": "sample_config"}]
@@ -165,7 +177,11 @@ class TestConfigDefinitionUnit:
         page_number = 1
         items_per_page = 10
 
-        internal_query = l_config_definition_query(page_number, items_per_page)
+        internal_query, internal_params = l_config_definition_query(
+            page_number, items_per_page
+        )
         l_config_definition(page_number, items_per_page)
 
-        mock_execute_query.assert_called_once_with(internal_query, mode="retrieve")
+        mock_execute_query.assert_called_once_with(
+            internal_query, params=internal_params, mode="retrieve"
+        )

--- a/tests/unit_tests/test_data_source.py
+++ b/tests/unit_tests/test_data_source.py
@@ -59,7 +59,7 @@ class TestDataStore:
         ds = DataStore()
 
         mock_cursor = mock_conn.cursor.return_value
-        mock_cursor.execute.assert_any_call(QUERY_CREATE_TABLE)
+        mock_cursor.execute.assert_any_call(QUERY_CREATE_TABLE, ())
         del ds
 
     @patch("app.utils.data.data_source.connect")
@@ -76,7 +76,7 @@ class TestDataStore:
         ds = DataStore()
 
         mock_cursor = mock_conn.cursor.return_value
-        mock_cursor.execute.assert_any_call(QUERY_CREATE_INDEX)
+        mock_cursor.execute.assert_any_call(QUERY_CREATE_INDEX, ())
         del ds
 
     @patch("app.utils.data.data_source.connect")


### PR DESCRIPTION
## Description

- The code written for the `ConfigDefinition` made us understand two things
    - We use `psycopg2` for all our DB interactions, and that brings us to building query templates.
    - Query templates, if not sanitized can lead to SQL Injection attacks, and takedown of the whole process.
    - We have refered to the comments made in PR #8 for info about **Parameterized Queries** and have implemented the same.

## Related Issue

- [x] Link to the related issue #9 

## Type of Change

- [x] Bugfix
- [x] New Feature

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass

