### PR TITLE
fix(config-definition): remove primary_key explicit field

### DIFF
--- a/app/api/v1/config_definition.py
+++ b/app/api/v1/config_definition.py
@@ -44,8 +44,7 @@ def create_config_definition(config_definition: CreateConfigDefinition):
         c_config_definition(
             config_definition.config_definition_key,
             config_definition.json_schema,
-            config_definition.primary_key,
-            config_definition.secondary_indexes,
+            config_definition.indexes,
         )
     except Exception as e:
         logger.exception(f"Error creating configuration definition: {e}")
@@ -97,7 +96,7 @@ def update_config_definition(
         The response for the update configuration definition request.
     """
     try:
-        u_config_definition(config_definition_key, config_definition.secondary_indexes)
+        u_config_definition(config_definition_key, config_definition.indexes)
     except Exception as e:
         logger.exception(f"Error updating configuration definition: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/models/config_definition.py
+++ b/app/models/config_definition.py
@@ -22,11 +22,7 @@ class CreateConfigDefinition(BaseModel):
         default=None,
         description="JSON Schema for validating configs belonging to this config definition.",
     )
-    primary_key: str = Field(
-        ...,
-        description="Field name to be used as the primary key. Must exist in the schema properties.",
-    )
-    secondary_indexes: Optional[List[str]] = Field(
+    indexes: Optional[List[str]] = Field(
         default_factory=list,
         description="List of field names to be indexed. Each must exist in the schema properties.",
     )
@@ -49,8 +45,7 @@ class CreateConfigDefinition(BaseModel):
                     },
                     "required": ["setting_string", "setting_object"],
                 },
-                "primary_key": "setting_string",
-                "secondary_indexes": ["setting_object.first_key"],
+                "indexes": ["setting_object.first_key"],
             }
         }
     )
@@ -61,7 +56,7 @@ class UpdateConfigDefinition(BaseModel):
     Represents an existing configuration definition to be updated in the internal table.
     """
 
-    secondary_indexes: List[str] = Field(
+    indexes: List[str] = Field(
         default_factory=list,
         description="List of field names to be indexed. Each must exist in the schema properties.",
     )

--- a/app/utils/config_definitions/queries.py
+++ b/app/utils/config_definitions/queries.py
@@ -11,7 +11,7 @@ import json
 
 
 def internal_c_definition_query(
-    config_type_key: str, json_schema: dict, primary_key: str, secondary_indexes: list
+    config_type_key: str, json_schema: dict, indexes: list
 ) -> tuple:
     """
     Insert a new configuration definition in the internal table.
@@ -19,56 +19,54 @@ def internal_c_definition_query(
     -- Parameters
     config_type_key: str
         The key for the configuration type.
-    primary_key: str
-        The primary key for the configuration type.
-    data: dict
-        The data for the configuration type.
+    indexes: list
+        The indexes for the configuration type.
 
     -- Returns
     str
         The SQL query to insert the configuration definition.
     """
     json_schema_str = json.dumps(json_schema)
-    secondary_indexes_str = (
-        "{" + ",".join(f'"{item}"' for item in secondary_indexes) + "}"
-    )
+    indexes_str = "{" + ",".join(f'"{item}"' for item in indexes) + "}"
 
     internal_query = f"""
-    INSERT INTO {settings.INTERNAL_TABLE} (config_type_key, json_schema, primary_key, secondary_indexes)
-    VALUES (%s, %s, %s, %s);
+    INSERT INTO {settings.INTERNAL_TABLE} (config_type_key, json_schema, indexes)
+    VALUES (%s, %s, %s);
     """
 
     return internal_query, (
         config_type_key,
         json_schema_str,
-        primary_key,
-        secondary_indexes_str,
+        indexes_str,
     )
 
 
-def internal_u_definition_query(config_type_key: str, secondary_indexes: list) -> tuple:
+def internal_u_definition_query(config_type_key: str, indexes: list) -> tuple:
     """
     Update a configuration definition in the internal table.
 
     -- Parameters
     config_type_key: str
         The key for the configuration type.
-    secondary_indexes: list
-        The secondary indexes for the configuration type.
+    indexes: list
+        The indexes for the configuration type.
 
     -- Returns
     tuple
         The SQL query to update the configuration definition and the parameters.
     """
-    secondary_indexes = "{" + ",".join(f'"{item}"' for item in secondary_indexes) + "}"
+    indexes = "{" + ",".join(f'"{item}"' for item in indexes) + "}"
 
     update_query = f"""
     UPDATE {settings.INTERNAL_TABLE}
-    SET secondary_indexes = %s
+    SET indexes = %s
     WHERE config_type_key = %s;
     """
 
-    return update_query, (secondary_indexes, config_type_key)
+    return update_query, (
+        indexes,
+        config_type_key,
+    )
 
 
 def internal_d_definition_query(config_type_key: str) -> tuple:
@@ -155,15 +153,13 @@ def l_index_query(config_type_key: str) -> tuple:
     return list_query, (config_type_key,)
 
 
-def c_config_definition_query(config_type_key: str, primary_key: str) -> tuple:
+def c_config_definition_query(config_type_key: str) -> tuple:
     """
     Create a new configuration definition in the internal table.
 
     -- Parameters
     config_type_key: str
         The key for the configuration type.
-    primary_key: str
-        The primary key for the configuration type.
 
     -- Returns
     tuple
@@ -171,7 +167,7 @@ def c_config_definition_query(config_type_key: str, primary_key: str) -> tuple:
     """
     creation_query = f"""
     CREATE TABLE IF NOT EXISTS {config_type_key} (
-        {primary_key} VARCHAR(255) PRIMARY KEY NOT NULL,
+        config_key VARCHAR(255) PRIMARY KEY NOT NULL,
         data JSONB NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/app/utils/config_definitions/validations.py
+++ b/app/utils/config_definitions/validations.py
@@ -27,70 +27,37 @@ def validate_schema_structure(json_schema: Dict[str, Any]) -> None:
         raise ValueError(f"Invalid JSON Schema provided: {e.message}")
 
 
-def validate_schema_pkey(json_schema: Dict[str, Any], primary_key: str) -> None:
-    """
-    Ensures that the primary key field exists in the schema properties.
-
-    -- Parameters
-    json_schema: Dict[str, Any]
-        The JSON Schema to validate against.
-
-    primary_key: str
-        The primary key field to validate.
-
-    """
-    if json_schema and not validate_schema_property(primary_key, json_schema):
-        raise ValueError(
-            f"The primary key '{primary_key}' is not defined in the schema properties."
-        )
-
-
-def validate_schema_sindex(
-    json_schema: Dict[str, Any], secondary_indexes: List[str]
-) -> None:
+def validate_schema_index(json_schema: Dict[str, Any], indexes: List[str]) -> None:
     """
     Ensures that each secondary index field exists in the schema properties.
 
     -- Parameters
     json_schema: Dict[str, Any]
         The JSON Schema to validate against.
-    secondary_indexes: List[str]
-        The secondary index fields to validate.
+    indexes: List[str]
+        The index fields to validate.
 
     """
     if not json_schema:
         return
 
-    for index in secondary_indexes:
+    for index in indexes:
         if not validate_schema_property(index, json_schema):
             raise ValueError(
-                f"The secondary index '{index}' is not defined in the schema properties."
+                f"The index '{index}' is not defined in the schema properties."
             )
 
 
-def validate_pkey(primary_key: str) -> None:
-    """
-    Validates the primary key field.
-
-    -- Parameters
-    primary_key: str
-        The primary key field to validate.
-
-    """
-    if not primary_key:
-        raise ValueError("Primary key cannot be empty.")
-
-
-def validate_sindex(secondary_indexes: List[str]) -> None:
+def validate_index(indexes: List[str]) -> None:
     """
     Validates the secondary index fields.
 
     -- Parameters
-    secondary_indexes: List[str]
+    indexes: List[str]
         The secondary index fields to validate.
 
     """
-    if len(secondary_indexes) != len(set(secondary_indexes)):
+    if len(indexes) != len(set(indexes)):
         raise ValueError("Duplicate secondary indexes are not allowed.")
 
 
@@ -121,47 +88,39 @@ def validate_schema_property(field_path: str, json_schema: Dict[str, Any]) -> bo
     return True
 
 
-def validate_config_creation(
-    json_schema: Dict[str, Any], primary_key: str, secondary_indexes: List[str]
-) -> None:
+def validate_config_creation(json_schema: Dict[str, Any], indexes: List[str]) -> None:
     """
     Validates the creation of a new configuration definition.
 
     -- Parameters
     json_schema: Dict[str, Any]
         The JSON Schema to validate against.
-    primary_key: str
-        The primary key field to validate.
-    secondary_indexes: List[str]
+    indexes: List[str]
         The secondary index fields to validate.
 
     """
-    validate_pkey(primary_key)
-    validate_sindex(secondary_indexes)
+    validate_index(indexes)
 
     validate_schema_structure(json_schema)
-    validate_schema_pkey(json_schema, primary_key)
-    validate_schema_sindex(json_schema, secondary_indexes)
+    validate_schema_index(json_schema, indexes)
     return None
 
 
-def validate_config_update(
-    json_schema: Dict[str, Any], secondary_indexes: List[str]
-) -> None:
+def validate_config_update(json_schema: Dict[str, Any], indexes: List[str]) -> None:
     """
     Validates the update of an existing configuration definition.
 
     -- Parameters
     json_schema: Dict[str, Any]
         The JSON Schema to validate against.
-    secondary_indexes: List[str]
-        The secondary index fields to validate.
+    indexes: List[str]
+        The index fields to validate.
 
     """
-    validate_sindex(secondary_indexes)
+    validate_index(indexes)
 
     validate_schema_structure(json_schema)
-    validate_schema_sindex(json_schema, secondary_indexes)
+    validate_schema_index(json_schema, indexes)
 
 
 def validate_list_params(page: int, page_size: int) -> None:

--- a/app/utils/data/data_source.py
+++ b/app/utils/data/data_source.py
@@ -8,7 +8,7 @@
 
 from psycopg2 import connect
 from app.utils.config.conf import settings
-from app.utils.config.queries import (
+from app.utils.data.queries import (
     QUERY_CREATE_TABLE,
     QUERY_CREATE_INDEX,
 )

--- a/app/utils/data/queries.py
+++ b/app/utils/data/queries.py
@@ -12,8 +12,7 @@ QUERY_CREATE_TABLE = f"""
 CREATE TABLE IF NOT EXISTS {settings.INTERNAL_TABLE} (
     config_type_key VARCHAR(255) PRIMARY KEY NOT NULL,
     json_schema JSONB,
-    primary_key VARCHAR(255) NOT NULL,
-    secondary_indexes TEXT[]
+    indexes TEXT[]
 );
 """
 
@@ -21,7 +20,7 @@ QUERY_CREATE_INDEX = f"""
 CREATE INDEX IF NOT EXISTS idx_{settings.DB_NAME}_json_schema
 ON {settings.INTERNAL_TABLE} USING gin (json_schema);
 
-CREATE INDEX IF NOT EXISTS idx_{settings.DB_NAME}_secondary_indexes 
-ON {settings.INTERNAL_TABLE} USING gin (secondary_indexes);
+CREATE INDEX IF NOT EXISTS idx_{settings.DB_NAME}_indexes 
+ON {settings.INTERNAL_TABLE} USING gin (indexes);
 
 """

--- a/tests/integration_tests/test_config_definition.py
+++ b/tests/integration_tests/test_config_definition.py
@@ -35,16 +35,14 @@ class TestConfigDefinitionIntegration:
             "type": "object",
             "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
         }
-        primary_key = "name"
-        secondary_indexes = ["date"]
+        indexes = ["date"]
 
-        c_config_definition(config_key, schema, primary_key, secondary_indexes)
+        c_config_definition(config_key, schema, indexes)
 
         yield {
             "config_key": config_key,
             "schema": schema,
-            "primary_key": primary_key,
-            "secondary_indexes": secondary_indexes,
+            "indexes": indexes,
         }
 
         d_config_definition(config_key)
@@ -62,8 +60,7 @@ class TestConfigDefinitionIntegration:
                 "type": "object",
                 "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
             },
-            "primary_key": "name",
-            "secondary_indexes": ["date"],
+            "indexes": ["date"],
         }
 
         response = client.post("/api/v1/config_definition/", json=payload)
@@ -96,7 +93,7 @@ class TestConfigDefinitionIntegration:
         This test verifies that an existing configuration definition is updated successfully.
         """
 
-        payload = {"secondary_indexes": ["name"]}
+        payload = {"indexes": ["name"]}
 
         response = client.put(
             f"/api/v1/config_definition/{setup_data['config_key']}", json=payload

--- a/tests/unit_tests/config_definition/test_create.py
+++ b/tests/unit_tests/config_definition/test_create.py
@@ -42,21 +42,16 @@ class TestConfigDefinitionCreate:
             "type": "object",
             "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
         }
-        primary_key_field = "name"
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index]
+        index = "date"
+        indexes_list = [index]
 
-        creation_query, creation_params = c_config_definition_query(
-            config_key, primary_key_field
-        )
+        creation_query, creation_params = c_config_definition_query(config_key)
         internal_query, internal_params = internal_c_definition_query(
-            config_key, schema, primary_key_field, secondary_indexes_list
+            config_key, schema, indexes_list
         )
-        index_query, index_params = c_index_query(config_key, secondary_index)
+        index_query, index_params = c_index_query(config_key, index)
 
-        c_config_definition(
-            config_key, schema, primary_key_field, secondary_indexes_list
-        )
+        c_config_definition(config_key, schema, indexes_list)
 
         mock_execute_query.assert_any_call(creation_query, creation_params)
         mock_execute_query.assert_any_call(internal_query, internal_params)
@@ -68,19 +63,16 @@ class TestConfigDefinitionCreate:
         Test that the function creates a new configuration definition.
         """
         config_key = "sample_config"
-        primary_key_field = "name"
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index]
+        index = "date"
+        indexes_list = [index]
 
-        creation_query, creation_params = c_config_definition_query(
-            config_key, primary_key_field
-        )
+        creation_query, creation_params = c_config_definition_query(config_key)
         internal_query, internal_params = internal_c_definition_query(
-            config_key, None, primary_key_field, secondary_indexes_list
+            config_key, None, indexes_list
         )
-        index_query, index_params = c_index_query(config_key, secondary_index)
+        index_query, index_params = c_index_query(config_key, index)
 
-        c_config_definition(config_key, None, primary_key_field, secondary_indexes_list)
+        c_config_definition(config_key, None, indexes_list)
 
         mock_execute_query.assert_any_call(creation_query, creation_params)
         mock_execute_query.assert_any_call(internal_query, internal_params)
@@ -93,89 +85,43 @@ class TestConfigDefinitionCreate:
         """
         config_key = "sample_config"
         schema = {"type": "string"}
-        primary_key_field = "name"
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index]
+        index = "date"
+        indexes_list = [index]
 
         with pytest.raises(ValueError):
-            c_config_definition(
-                config_key, schema, primary_key_field, secondary_indexes_list
-            )
+            c_config_definition(config_key, schema, indexes_list)
         mock_execute_query.assert_not_called()
 
     @patch.object(DataStore, "_execute_query")
-    def test_create_o_pkey(self, mock_execute_query):
+    def test_create_d_index(self, mock_execute_query):
         """
-        Test that the function raises an exception if the primary key is not supplied.
+        Test that the function raises an exception if the index is duplicated.
         """
         config_key = "sample_config"
         schema = {
             "type": "object",
             "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
         }
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index]
+        index = "date"
+        indexes_list = [index, index]
 
         with pytest.raises(ValueError):
-            c_config_definition(config_key, schema, "", secondary_indexes_list)
+            c_config_definition(config_key, schema, indexes_list)
         mock_execute_query.assert_not_called()
 
     @patch.object(DataStore, "_execute_query")
-    def test_create_n_pkey(self, mock_execute_query):
+    def test_create_n_index(self, mock_execute_query):
         """
-        Test that the function raises an exception if the primary key is not in the schema.
+        Test that the function raises an exception if the index is not in the schema.
         """
         config_key = "sample_config"
         schema = {
             "type": "object",
             "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
         }
-        primary_key_field = "age"
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index]
+        index = "age"
+        indexes_list = [index]
 
         with pytest.raises(ValueError):
-            c_config_definition(
-                config_key, schema, primary_key_field, secondary_indexes_list
-            )
-        mock_execute_query.assert_not_called()
-
-    @patch.object(DataStore, "_execute_query")
-    def test_create_d_sindex(self, mock_execute_query):
-        """
-        Test that the function raises an exception if the secondary index is duplicated.
-        """
-        config_key = "sample_config"
-        schema = {
-            "type": "object",
-            "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
-        }
-        primary_key_field = "name"
-        secondary_index = "date"
-        secondary_indexes_list = [secondary_index, secondary_index]
-
-        with pytest.raises(ValueError):
-            c_config_definition(
-                config_key, schema, primary_key_field, secondary_indexes_list
-            )
-        mock_execute_query.assert_not_called()
-
-    @patch.object(DataStore, "_execute_query")
-    def test_create_n_sindex(self, mock_execute_query):
-        """
-        Test that the function raises an exception if the secondary index is not in the schema.
-        """
-        config_key = "sample_config"
-        schema = {
-            "type": "object",
-            "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
-        }
-        primary_key_field = "name"
-        secondary_index = "age"
-        secondary_indexes_list = [secondary_index]
-
-        with pytest.raises(ValueError):
-            c_config_definition(
-                config_key, schema, primary_key_field, secondary_indexes_list
-            )
+            c_config_definition(config_key, schema, indexes_list)
         mock_execute_query.assert_not_called()

--- a/tests/unit_tests/config_definition/test_update.py
+++ b/tests/unit_tests/config_definition/test_update.py
@@ -32,7 +32,7 @@ class TestConfigDefintionUpdate:
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
     @patch.object(DataStore, "_execute_query")
-    def test_update_w_sindex(self, mock_execute_query, mock_r_config_definition):
+    def test_update_w_index(self, mock_execute_query, mock_r_config_definition):
         """
         Test that the function updates a configuration definition.
 
@@ -47,8 +47,7 @@ class TestConfigDefintionUpdate:
                 "type": "object",
                 "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
             },
-            "primary_key": "name",
-            "secondary_indexes": ["date"],
+            "indexes": ["date"],
         }
 
         internal_query, internal_params = internal_u_definition_query(
@@ -82,7 +81,7 @@ class TestConfigDefintionUpdate:
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
     @patch.object(DataStore, "_execute_query")
-    def test_update_d_sindex(self, mock_execute_query, mock_r_config_definition):
+    def test_update_d_index(self, mock_execute_query, mock_r_config_definition):
         """
         Test that the function raises an exception if the secondary index is duplicated.
         """
@@ -91,8 +90,7 @@ class TestConfigDefintionUpdate:
                 "type": "object",
                 "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
             },
-            "primary_key": "name",
-            "secondary_indexes": ["date"],
+            "indexes": ["date"],
         }
 
         config_key = "sample_config"
@@ -104,7 +102,7 @@ class TestConfigDefintionUpdate:
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
     @patch.object(DataStore, "_execute_query")
-    def test_update_n_sindex(self, mock_execute_query, mock_r_config_definition):
+    def test_update_n_index(self, mock_execute_query, mock_r_config_definition):
         """
         Test that the function raises an exception if the secondary index is not found.
         """
@@ -113,8 +111,7 @@ class TestConfigDefintionUpdate:
                 "type": "object",
                 "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
             },
-            "primary_key": "name",
-            "secondary_indexes": ["date"],
+            "indexes": ["date"],
         }
 
         config_key = "sample_config"

--- a/tests/unit_tests/test_data_source.py
+++ b/tests/unit_tests/test_data_source.py
@@ -8,7 +8,7 @@
 
 from unittest.mock import patch, MagicMock
 from app.utils.config.conf import settings
-from app.utils.config.queries import (
+from app.utils.data.queries import (
     QUERY_CREATE_TABLE,
     QUERY_CREATE_INDEX,
 )


### PR DESCRIPTION
## Description

 - The `primary_key` explicit field made things complicated, and is unnecessary.
    - The previous setup required a `primary_key` field string to be provided for creation of `ConfigDefinition`
    - It is removed, and the `secondary_indexes` field is now `indexes`
    - The validations for `p_key` and other utilities is removed as well.
    - While creating the definition table, the `PRIMARY KEY`  is now `config_key`.

## Related Issue

- [X] Link to the related issue (if applicable) #18 

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Documentation

## Checklist

- [X] Code follows the project style guidelines
- [X] Tests have been added/updated
- [X] All tests pass

## Additional Notes

- The `app/utils/config/queries.py` is migrated to `app/utils/data/queries.py`
