### PR TITLE
feat(tests): re-factor testing variable storage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2022] [Waterdip Labs Pvt. Ltd.]
+   Copyright [2024] [Qreater]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/app/utils/config_definitions/utils.py
+++ b/app/utils/config_definitions/utils.py
@@ -21,7 +21,9 @@ from app.utils.config_definitions.queries import (
 
 from app.utils.config_definitions.validations import (
     validate_config_creation,
+    validate_config_read,
     validate_config_update,
+    validate_config_delete,
     validate_list_params,
 )
 
@@ -44,7 +46,7 @@ def c_config_definition(config_type_key: str, json_schema: dict, indexes: list):
 
     """
 
-    validate_config_creation(json_schema, indexes)
+    validate_config_creation(config_type_key, json_schema, indexes)
 
     internal_query, internal_params = internal_c_definition_query(
         config_type_key, json_schema, indexes
@@ -76,6 +78,8 @@ def r_config_definition(config_type_key: str):
     dict
         The configuration definition.
     """
+
+    validate_config_read(config_type_key)
 
     query, params = r_config_definition_query(config_type_key)
     result = data_store._execute_query(query, params=params, mode="retrieve")
@@ -137,6 +141,9 @@ def d_config_definition(config_type_key: str):
     -- Returns
     None
     """
+
+    validate_config_delete(config_type_key)
+
     internal_query, internal_params = internal_d_definition_query(config_type_key)
     data_store._execute_query(internal_query, internal_params)
 
@@ -160,7 +167,9 @@ def l_config_definition(page: int = 1, page_size: int = 10):
     list
         The configuration definitions.
     """
+
     validate_list_params(page, page_size)
+
     query, params = l_config_definition_query(page, page_size)
     result = data_store._execute_query(query, params=params, mode="retrieve")
 

--- a/app/utils/config_definitions/validations.py
+++ b/app/utils/config_definitions/validations.py
@@ -7,7 +7,25 @@
 """
 
 import jsonschema
+import re
 from typing import Any, Dict, List
+
+
+def validate_config_type_key(config_type_key: str) -> None:
+    """
+    Validates the configuration type key.
+
+    -- Parameters
+    config_type_key: str
+        The configuration type key to validate.
+
+    """
+    if not config_type_key:
+        raise ValueError("Configuration type key must be provided.")
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]{2,}$", config_type_key):
+        raise ValueError(
+            "Configuration type key must start with a letter and contain only alphanumeric characters and underscores."
+        )
 
 
 def validate_schema_structure(json_schema: Dict[str, Any]) -> None:
@@ -88,22 +106,39 @@ def validate_schema_property(field_path: str, json_schema: Dict[str, Any]) -> bo
     return True
 
 
-def validate_config_creation(json_schema: Dict[str, Any], indexes: List[str]) -> None:
+def validate_config_creation(
+    config_type_key: str, json_schema: Dict[str, Any], indexes: List[str]
+) -> None:
     """
     Validates the creation of a new configuration definition.
 
     -- Parameters
+    config_type_key: str
+        The key for the configuration type.
     json_schema: Dict[str, Any]
         The JSON Schema to validate against.
     indexes: List[str]
         The secondary index fields to validate.
 
     """
+    validate_config_type_key(config_type_key)
     validate_index(indexes)
 
     validate_schema_structure(json_schema)
     validate_schema_index(json_schema, indexes)
     return None
+
+
+def validate_config_read(config_type_key: str) -> None:
+    """
+    Validates the retrieval of a configuration definition.
+
+    -- Parameters
+    config_type_key: str
+        The key for the configuration type.
+
+    """
+    validate_config_type_key(config_type_key)
 
 
 def validate_config_update(json_schema: Dict[str, Any], indexes: List[str]) -> None:
@@ -121,6 +156,18 @@ def validate_config_update(json_schema: Dict[str, Any], indexes: List[str]) -> N
 
     validate_schema_structure(json_schema)
     validate_schema_index(json_schema, indexes)
+
+
+def validate_config_delete(config_type_key: str) -> None:
+    """
+    Validates the deletion of a configuration definition.
+
+    -- Parameters
+    config_type_key: str
+        The key for the configuration type.
+
+    """
+    validate_config_type_key(config_type_key)
 
 
 def validate_list_params(page: int, page_size: int) -> None:

--- a/tests/unit_tests/config_definition/payloads/__init__.py
+++ b/tests/unit_tests/config_definition/payloads/__init__.py
@@ -1,0 +1,7 @@
+"""
+
+ Copyright 2024 @Qreater
+ Licensed under the Apache License, Version 2.0.
+ See: http://www.apache.org/licenses/LICENSE-2.0
+
+"""

--- a/tests/unit_tests/config_definition/payloads/payload_extractor.py
+++ b/tests/unit_tests/config_definition/payloads/payload_extractor.py
@@ -1,0 +1,50 @@
+"""
+
+ Copyright 2024 @Qreater
+ Licensed under the Apache License, Version 2.0.
+ See: http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+
+import os
+import json
+
+
+def extract_payload():
+    """
+    Extracts the test payload from the payload file.
+
+    -- Returns
+    dict
+        The test payload.
+    """
+    payload_path = os.path.join(os.path.dirname(__file__), "payloads.json")
+
+    with open(payload_path, "r") as file:
+        payload = json.load(file)
+
+    return payload
+
+
+def extract_payload_params(payload):
+    """
+    Extracts the test parameters from the test payload.
+
+    -- Parameters
+    test_payload: dict
+        The test payload.
+
+    -- Returns
+    tuple
+        The test parameters.
+    """
+    config_key = payload.get("config_key")
+    schema = payload.get("schema")
+
+    index = payload.get("index")
+    indexes = payload.get("indexes")
+
+    page = payload.get("page")
+    page_size = payload.get("page_size")
+
+    return (config_key, schema, index, indexes, page, page_size)

--- a/tests/unit_tests/config_definition/payloads/payloads.json
+++ b/tests/unit_tests/config_definition/payloads/payloads.json
@@ -1,0 +1,114 @@
+{
+    "create": {
+      "test_create_w_schema": {
+        "config_key": "sample_config",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        },
+        "index": "date",
+        "indexes": ["date"]
+      },
+      "test_create_o_schema": {
+        "config_key": "sample_config",
+        "schema": null,
+        "index": "date",
+        "indexes": ["date"]
+      },
+      "test_create_n_schema": {
+        "config_key": "sample_config",
+        "schema": {
+          "type": "string"
+        },
+        "index": "date",
+        "indexes": ["date"]
+      },
+      "test_create_d_sindex": {
+        "config_key": "sample_config",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        },
+        "indexes": ["date", "date"]
+      },
+      "test_create_n_sindex": {
+        "config_key": "sample_config",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        },
+        "index": "age",
+        "indexes": ["age"]
+      }
+    },
+    "read": {
+      "test_read_w_key": {
+        "config_key": "sample_config"
+      },
+      "test_read_o_key": {
+        "config_key": ""
+      }
+    },
+    "update": {
+      "test_update_w_index": {
+        "config_key": "sample_config",
+        "indexes": ["name"]
+      },
+      "test_update_d_index": {
+        "config_key": "sample_config",
+        "indexes": ["name", "name"]
+      },
+      "test_update_n_index": {
+        "config_key": "sample_config",
+        "indexes": ["dog"]
+      }
+    },
+    "delete": {
+      "test_delete_w_key": {
+        "config_key": "sample_config"
+      },
+      "test_delete_o_key": {
+        "config_key": ""
+      }
+    },
+    "list": {
+      "test_list_w_params": {
+        "page": 1,
+        "page_size": 10
+      },
+      "test_list_n_page": {
+        "page": -1,
+        "page_size": 10
+      },
+      "test_list_n_nlimit": {
+        "page": 1,
+        "page_size": -1
+      },
+      "test_list_n_plimit": {
+        "page": 1,
+        "page_size": 101
+      }
+    }
+  }
+  

--- a/tests/unit_tests/config_definition/test_delete.py
+++ b/tests/unit_tests/config_definition/test_delete.py
@@ -7,7 +7,7 @@
 """
 
 from unittest.mock import patch, MagicMock
-
+import pytest
 from app.utils.data.data_source import DataStore
 
 with patch("app.utils.data.data_source.connect") as mock_connect:
@@ -21,42 +21,72 @@ from app.utils.config_definitions.queries import (
     internal_d_definition_query,
 )
 
+from tests.unit_tests.config_definition.payloads.payload_extractor import (
+    extract_payload,
+    extract_payload_params,
+)
 
-class TestConfigDefintionDelete:
+
+class TestConfigDefinitionDelete:
     """
     Unit tests for the delete functions of the configuration definition module.
     """
 
-    @patch.object(DataStore, "_execute_query")
-    def test_delete_w_key(self, mock_execute_query):
+    @pytest.fixture(scope="class")
+    def get_payload(self):
         """
-        Test that the function deletes a configuration definition.
-
-        This test verifies that the function deletes a configuration definition from the internal table.
+        Extracts the test payload from the payload file for the test suite.
         """
+        return extract_payload()["delete"]
 
-        config_key = "sample_config"
+    def _run_d_config_definition(
+        self,
+        payload_extract,
+        mock_execute_query,
+        expect_error=False,
+    ):
+        """
+        Helper function to run d_config_definition and handle assertions.
+        """
+        (
+            config_key,
+            _,
+            _,
+            _,
+            _,
+            _,
+        ) = extract_payload_params(payload_extract)
 
         delete_query, delete_params = d_config_definition_query(config_key)
         internal_query, internal_params = internal_d_definition_query(config_key)
+
+        if expect_error:
+            with pytest.raises(ValueError):
+                d_config_definition(config_key)
+            mock_execute_query.assert_not_called()
+            return
+
         d_config_definition(config_key)
 
         mock_execute_query.assert_any_call(delete_query, delete_params)
         mock_execute_query.assert_any_call(internal_query, internal_params)
 
     @patch.object(DataStore, "_execute_query")
-    def test_delete_o_key(self, mock_execute_query):
+    def test_delete_w_key(self, mock_execute_query, get_payload):
         """
-        Test that the function deletes a configuration definition with no key.
-
-        This test verifies that the function deletes a configuration definition from the internal table without a key.
+        Test that the function deletes a configuration definition with a valid key.
         """
+        payload_extract = get_payload["test_delete_w_key"]
+        self._run_d_config_definition(
+            payload_extract, mock_execute_query, expect_error=False
+        )
 
-        config_key = ""
-
-        delete_query, delete_params = d_config_definition_query(config_key)
-        internal_query, internal_params = internal_d_definition_query(config_key)
-        d_config_definition(config_key)
-
-        mock_execute_query.assert_any_call(delete_query, delete_params)
-        mock_execute_query.assert_any_call(internal_query, internal_params)
+    @patch.object(DataStore, "_execute_query")
+    def test_delete_o_key(self, mock_execute_query, get_payload):
+        """
+        Test that the function raises an exception when trying to delete with an empty key.
+        """
+        payload_extract = get_payload["test_delete_o_key"]
+        self._run_d_config_definition(
+            payload_extract, mock_execute_query, expect_error=True
+        )

--- a/tests/unit_tests/config_definition/test_read.py
+++ b/tests/unit_tests/config_definition/test_read.py
@@ -7,7 +7,7 @@
 """
 
 from unittest.mock import patch, MagicMock
-
+import pytest
 from app.utils.data.data_source import DataStore
 
 with patch("app.utils.data.data_source.connect") as mock_connect:
@@ -18,29 +18,63 @@ with patch("app.utils.data.data_source.connect") as mock_connect:
 
 from app.utils.config_definitions.queries import r_config_definition_query
 
+from tests.unit_tests.config_definition.payloads.payload_extractor import (
+    extract_payload,
+    extract_payload_params,
+)
 
-class TestConfigDefintionRead:
+
+class TestConfigDefinitionRead:
     """
     Unit tests for the read functions of the configuration definition module.
     """
+
+    @pytest.fixture(scope="class")
+    def get_payload(self):
+        """
+        Extracts the test payload from the payload file for the test suite.
+        """
+        return extract_payload()["read"]
+
+    def _run_r_config_definition(
+        self, payload_extract, mock_execute_query, expect_error=False
+    ):
+        """
+        Helper function to run r_config_definition and handle assertions.
+        """
+        (
+            config_key,
+            _,
+            _,
+            _,
+            _,
+            _,
+        ) = extract_payload_params(payload_extract)
+
+        if expect_error:
+            with pytest.raises(ValueError):
+                r_config_definition(config_key)
+            mock_execute_query.assert_not_called()
+        else:
+            internal_query, internal_params = r_config_definition_query(config_key)
+            r_config_definition(config_key)
+
+            mock_execute_query.assert_called_once_with(
+                internal_query, params=internal_params, mode="retrieve"
+            )
 
     @patch.object(
         DataStore,
         "_execute_query",
         return_value=[{"json_schema": '{"type": "object"}'}],
     )
-    def test_read_w_key(self, mock_execute_query):
+    def test_read_w_key(self, mock_execute_query, get_payload):
         """
-        Test that the function retrieves a configuration definition.
+        Test that the function retrieves a configuration definition with a given key.
         """
-
-        config_key = "sample_config"
-
-        internal_query, internal_params = r_config_definition_query(config_key)
-        r_config_definition(config_key)
-
-        mock_execute_query.assert_called_once_with(
-            internal_query, params=internal_params, mode="retrieve"
+        payload_extract = get_payload["test_read_w_key"]
+        self._run_r_config_definition(
+            payload_extract, mock_execute_query, expect_error=False
         )
 
     @patch.object(
@@ -48,16 +82,11 @@ class TestConfigDefintionRead:
         "_execute_query",
         return_value=[{"json_schema": '{"type": "object"}'}],
     )
-    def test_read_o_key(self, mock_execute_query):
+    def test_read_o_key(self, mock_execute_query, get_payload):
         """
-        Test that the function retrieves a configuration definition if key is not given.
+        Test that the function raises a ValueError if the config key is not given.
         """
-
-        config_key = ""
-
-        internal_query, internal_params = r_config_definition_query(config_key)
-        r_config_definition(config_key)
-
-        mock_execute_query.assert_called_once_with(
-            internal_query, params=internal_params, mode="retrieve"
+        payload_extract = get_payload["test_read_o_key"]
+        self._run_r_config_definition(
+            payload_extract, mock_execute_query, expect_error=True
         )


### PR DESCRIPTION
## Description
- Previously the testing kit-variables tend to be stuck under each testing definition, and would have duplicates declared everywhere.
    - The testing utility variables are switched to `payloads/payloads.json`.
    - The utility testing variables are accessed through a `payload_extractor` located in `payloads/payload_extractor.py`.
    - In the same file, `extract_payload_params` exists to give out the necessary configurations for each testing utility (CRUDL)
    - The testing kit is refactored such that there is one helper function which decides the flow of the test, and several tests use the flow with options for testing error conditions and success stories.
    - This helps maintain sanity and base information about how the tests are being conducted, and also abstract most of the unit testing.

## Related Issue

- [x] Link to the related issue #16 

## Type of Change

- [x] Bugfix
- [x] New Feature

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass

## Additional Notes
- Several new validations upon detection to be absent during testing were added.
- `LICENSE` has been patched for a typo on the organization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated copyright information in the LICENSE file to reflect current ownership.
  - Enhanced validation logic for configuration definitions, ensuring stricter adherence to expected formats and improving data integrity.
  
- **Bug Fixes**
  - Corrected typographical errors in test class names for better clarity.
  
- **Tests**
  - Introduced new fixtures for efficient payload extraction across various test files, improving test organization and maintainability.
  - Refactored test methods to utilize helper functions for common logic, enhancing readability and reducing redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->