### PR TITLE
feat(config): delete API, tests and verification

### DIFF
--- a/backend/app/api/v1/config.py
+++ b/backend/app/api/v1/config.py
@@ -8,9 +8,7 @@
 
 from fastapi import APIRouter, HTTPException
 
-from app.utils.configs.utils import (
-    c_config,
-)
+from app.utils.configs.utils import c_config, d_config
 
 from app.models.config import CreateConfig
 
@@ -47,3 +45,30 @@ def create_config(config_definition_key: str, config: CreateConfig):
         raise HTTPException(status_code=500, detail=str(e))
 
     return {"message": "Configuration created successfully."}
+
+
+@router.delete("/{config_key}")
+def delete_config(config_definition_key: str, config_key: str):
+    """
+    Delete a configuration.
+
+    -- Parameters
+    config_definition_key: str
+        The key for the configuration type.
+    config_key: str
+        The key for the configuration
+
+    -- Returns
+    DeleteConfigResponse
+        The response for the delete configuration request.
+    """
+    try:
+        d_config(
+            config_definition_key,
+            config_key,
+        )
+    except Exception as e:
+        logger.exception(f"Error deleting configuration: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"message": "Configuration deleted successfully."}

--- a/backend/app/utils/configs/queries.py
+++ b/backend/app/utils/configs/queries.py
@@ -44,3 +44,26 @@ def c_config_query(config_definition_key: str, config_key: str, data: dict) -> t
         created_at,
         modified_at,
     )
+
+
+def d_config_query(config_definition_key: str, config_key: str) -> tuple:
+    """
+    Delete a configuration from the configuration definition table.
+
+    -- Parameters
+    config_definition_key: str
+        The key for the configuration definition.
+    config_key: str
+        The key for the configuration.
+
+    -- Returns
+    str
+        The SQL query to delete the configuration.
+    """
+
+    query = f"""
+    DELETE FROM {config_definition_key}
+    WHERE config_key = %s;
+    """
+
+    return query, (config_key,)

--- a/backend/app/utils/configs/utils.py
+++ b/backend/app/utils/configs/utils.py
@@ -6,12 +6,11 @@
 
 """
 
-from app.utils.configs.queries import (
-    c_config_query,
-)
+from app.utils.configs.queries import c_config_query, d_config_query
 
 from app.utils.configs.validations import (
     validate_config_creation,
+    validate_config_deletion,
 )
 
 from app.utils.data.data_source import DataStore
@@ -38,5 +37,24 @@ def c_config(config_definition_key: str, config_key: str, data: dict):
         config_definition_key, config_key, data
     )
     data_store._execute_query(creation_query, creation_params)
+
+    return None
+
+
+def d_config(config_definition_key: str, config_key: str):
+    """
+    Delete a configuration from the config definition.
+
+    -- Parameters
+    config_definition_key: str
+        The key for the configuration definition.
+    config_key: str
+        The key for the configuration.
+    """
+
+    validate_config_deletion(config_definition_key, config_key)
+
+    deletion_query, deletion_params = d_config_query(config_definition_key, config_key)
+    data_store._execute_query(deletion_query, deletion_params)
 
     return None

--- a/backend/app/utils/configs/validations.py
+++ b/backend/app/utils/configs/validations.py
@@ -9,6 +9,7 @@
 import jsonschema
 import re
 
+from app.utils.config_definitions.validations import validate_config_definition_key
 from app.utils.config_definitions.utils import r_config_definition
 
 
@@ -68,7 +69,24 @@ def validate_config_creation(
     data: dict
         The data for the configuration.
     """
+    validate_config_definition_key(config_definition_key)
     validate_config_key(config_key)
     validate_config_data(config_definition_key, data)
+
+    return None
+
+
+def validate_config_deletion(config_definition_key: str, config_key: str) -> None:
+    """
+    Validates the deletion of a configuration.
+
+    -- Parameters
+    config_definition_key: str
+        The key for the configuration definition.
+    config_key: str
+        The key for the configuration.
+    """
+    validate_config_definition_key(config_definition_key)
+    validate_config_key(config_key)
 
     return None

--- a/backend/tests/integration_tests/config/test_config.py
+++ b/backend/tests/integration_tests/config/test_config.py
@@ -68,3 +68,10 @@ class TestConfigIntegration:
         """
         payload_extract = get_payload["test_create_config"]
         self._run_test(payload_extract)
+
+    def test_delete_config(self, get_payload):
+        """
+        Test deletion of a configuration.
+        """
+        payload_extract = get_payload["test_delete_config"]
+        self._run_test(payload_extract)

--- a/backend/tests/integration_tests/payloads/payloads.json
+++ b/backend/tests/integration_tests/payloads/payloads.json
@@ -91,5 +91,13 @@
         "expected_response": {
             "message": "Configuration created successfully."
         }
+    },
+    "test_delete_config": {
+        "method": "DELETE",
+        "url": "/api/v1/config_definition/test_config/config/test",
+        "expected_status": 200,
+        "expected_response": {
+            "message": "Configuration deleted successfully."
+        }
     }
 }

--- a/backend/tests/unit_tests/config/payloads/payloads.json
+++ b/backend/tests/unit_tests/config/payloads/payloads.json
@@ -60,7 +60,24 @@
     },
     "read": {},
     "update": {},
-    "delete": {},
+    "delete": {
+      "test_delete_w_key": {
+        "config_key": "sample_config",
+        "config_definition_key": "sample_config_definition"
+      },
+      "test_delete_o_key": {
+        "config_key": "",
+        "config_definition_key": "sample_config_definition"
+      },
+      "test_delete_w_cd_key": {
+        "config_key": "sample_config",
+        "config_definition_key": "sample_config_definition"
+      },
+      "test_delete_o_cd_key": {
+        "config_key": "sample_config",
+        "config_definition_key": ""
+      }
+    },
     "list": {}
   }
   

--- a/backend/tests/unit_tests/config/test_delete.py
+++ b/backend/tests/unit_tests/config/test_delete.py
@@ -1,0 +1,99 @@
+"""
+
+ Copyright 2024 @Qreater
+ Licensed under the Apache License, Version 2.0.
+ See: http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.utils.data.data_source import DataStore
+
+with patch("app.utils.data.data_source.connect") as mock_connect:
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+
+    from app.utils.configs.utils import (
+        d_config,
+    )
+
+from app.utils.configs.queries import (
+    d_config_query,
+)
+
+from tests.unit_tests.config.payloads.payload_extractor import (
+    extract_payload_params,
+    extract_payload,
+)
+
+
+class TestConfigDelete:
+    """
+    Test suite for the config deletion functions.
+    """
+
+    @pytest.fixture(scope="class")
+    def get_payload(self):
+        """
+        Extracts the test payload from the payload file for the test suite.
+        """
+        return extract_payload()["delete"]
+
+    def _run_d_config(
+        self,
+        payload_extract,
+        mock_execute_query,
+        expect_error=False,
+    ):
+        """
+        Helper function to run d_config and handle assertions.
+        """
+        (config_definition_key, config_key, _, _) = extract_payload_params(
+            payload_extract
+        )
+
+        delete_query, delete_params = d_config_query(config_definition_key, config_key)
+
+        if expect_error:
+            with pytest.raises(ValueError):
+                d_config(config_definition_key, config_key)
+                mock_execute_query.assert_not_called()
+            return
+
+        d_config(config_definition_key, config_key)
+        mock_execute_query.assert_called_once()
+
+    @patch.object(DataStore, "_execute_query")
+    def test_delete_w_key(self, mock_execute_query, get_payload):
+        """
+        Test the deletion of a configuration with a key.
+        """
+        payload_extract = get_payload["test_delete_w_key"]
+        self._run_d_config(payload_extract, mock_execute_query)
+
+    @patch.object(DataStore, "_execute_query")
+    def test_delete_o_key(self, mock_execute_query, get_payload):
+        """
+        Test the deletion of a configuration without a key.
+        """
+        payload_extract = get_payload["test_delete_o_key"]
+        self._run_d_config(payload_extract, mock_execute_query, expect_error=True)
+
+    @patch.object(DataStore, "_execute_query")
+    def test_delete_w_cd_key(self, mock_execute_query, get_payload):
+        """
+        Test the deletion of a configuration with a key and config definition key.
+        """
+        payload_extract = get_payload["test_delete_w_cd_key"]
+        self._run_d_config(payload_extract, mock_execute_query)
+
+    @patch.object(DataStore, "_execute_query")
+    def test_delete_o_cd_key(self, mock_execute_query, get_payload):
+        """
+        Test the deletion of a configuration without a key and config definition key.
+        """
+        payload_extract = get_payload["test_delete_o_cd_key"]
+        self._run_d_config(payload_extract, mock_execute_query, expect_error=True)


### PR DESCRIPTION
## Description

- Added the `config` deletion API.
- Added tests to support the API for both unit and integration purposes.
- Tested it out with a deployment, works fine!

## Related Issue

- [x] Link to the related issue (if applicable) #30 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass

## Follow Ups

Issues will be created based on this, but observations are

- Config creation API and it's utilities can be cleaned-up.
- More appropriate test cases, and edge-case covering can be added to the set-up. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for deleting configurations.
	- Added validation for configuration deletion requests.
- **Bug Fixes**
	- Enhanced error handling during configuration deletion.
- **Tests**
	- Implemented unit tests for the configuration deletion functionality.
	- Added integration tests to verify the deletion process.
	- Expanded test cases for various deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->