### PR TITLE
refactor(config): utilities and docstrings for `config` and `config-def`

### DIFF
--- a/backend/app/api/v1/config.py
+++ b/backend/app/api/v1/config.py
@@ -26,7 +26,7 @@ def create_config(config_definition_key: str, config: CreateConfig):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     config: CreateConfig
         The data for the configuration
 
@@ -54,7 +54,7 @@ def delete_config(config_definition_key: str, config_key: str):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     config_key: str
         The key for the configuration
 

--- a/backend/app/api/v1/config_definition.py
+++ b/backend/app/api/v1/config_definition.py
@@ -58,7 +58,7 @@ def get_config_definition(config_definition_key: str):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     GetConfigDefinitionResponse
@@ -85,7 +85,7 @@ def update_config_definition(
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     config_definition: UpdateConfigDefinition
         The configuration definition to update.
 
@@ -109,7 +109,7 @@ def delete_config_definition(config_definition_key: str):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     DeleteConfigDefinitionResponse

--- a/backend/app/utils/config_definitions/queries.py
+++ b/backend/app/utils/config_definitions/queries.py
@@ -18,9 +18,9 @@ def internal_c_definition_query(
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     indexes: list
-        The indexes for the configuration type.
+        The indexes for the configuration definition.
 
     -- Returns
     str
@@ -47,9 +47,9 @@ def internal_u_definition_query(config_definition_key: str, indexes: list) -> tu
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     indexes: list
-        The indexes for the configuration type.
+        The indexes for the configuration definition.
 
     -- Returns
     tuple
@@ -75,7 +75,7 @@ def internal_d_definition_query(config_definition_key: str) -> tuple:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     tuple
@@ -91,11 +91,11 @@ def internal_d_definition_query(config_definition_key: str) -> tuple:
 
 def c_index_query(config_definition_key: str, index: str) -> tuple:
     """
-    Create an index on a configuration type.
+    Create an index on a configuration definition.
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     index: str
         The index to create.
 
@@ -113,11 +113,11 @@ def c_index_query(config_definition_key: str, index: str) -> tuple:
 
 def d_index_query(config_definition_key: str, index: str) -> tuple:
     """
-    Remove an index on a configuration type.
+    Remove an index on a configuration definition.
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     index: str
         The index to remove.
 
@@ -134,11 +134,11 @@ def d_index_query(config_definition_key: str, index: str) -> tuple:
 
 def l_index_query(config_definition_key: str) -> tuple:
     """
-    List all indexes on a configuration type.
+    List all indexes on a configuration definition.
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     tuple
@@ -159,7 +159,7 @@ def c_config_definition_query(config_definition_key: str) -> tuple:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     tuple
@@ -183,7 +183,7 @@ def r_config_definition_query(config_definition_key: str) -> tuple:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     tuple
@@ -202,7 +202,7 @@ def d_config_definition_query(config_definition_key: str) -> tuple:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     tuple

--- a/backend/app/utils/config_definitions/utils.py
+++ b/backend/app/utils/config_definitions/utils.py
@@ -38,11 +38,11 @@ def c_config_definition(config_definition_key: str, json_schema: dict, indexes: 
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     json_schema: dict
-        The JSON schema for the configuration type.
+        The JSON schema for the configuration definition.
     indexes: list
-        The indexes for the configuration type.
+        The indexes for the configuration definition.
 
     """
 
@@ -72,7 +72,7 @@ def r_config_definition(config_definition_key: str):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     dict
@@ -96,9 +96,9 @@ def u_config_definition(config_definition_key: str, indexes: list):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     indexes: list
-        The indexes for the configuration type.
+        The indexes for the configuration definition.
 
     """
 
@@ -136,7 +136,7 @@ def d_config_definition(config_definition_key: str):
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     -- Returns
     None

--- a/backend/app/utils/config_definitions/validations.py
+++ b/backend/app/utils/config_definitions/validations.py
@@ -13,18 +13,18 @@ from typing import Any, Dict, List
 
 def validate_config_definition_key(config_definition_key: str) -> None:
     """
-    Validates the configuration type key.
+    Validates the configuration definition key.
 
     -- Parameters
     config_definition_key: str
-        The configuration type key to validate.
+        The configuration definition key to validate.
 
     """
     if not config_definition_key:
-        raise ValueError("Configuration type key must be provided.")
+        raise ValueError("Configuration definition key must be provided.")
     if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]{2,}$", config_definition_key):
         raise ValueError(
-            "Configuration type key must start with a letter and contain only alphanumeric characters and underscores."
+            "Configuration definition key must start with a letter and contain only alphanumeric characters and underscores."
         )
 
 
@@ -114,7 +114,7 @@ def validate_config_creation(
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     json_schema: Dict[str, Any]
         The JSON Schema to validate against.
     indexes: List[str]
@@ -135,7 +135,7 @@ def validate_config_read(config_definition_key: str) -> None:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     """
     validate_config_definition_key(config_definition_key)
@@ -164,7 +164,7 @@ def validate_config_delete(config_definition_key: str) -> None:
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
 
     """
     validate_config_definition_key(config_definition_key)

--- a/backend/app/utils/configs/queries.py
+++ b/backend/app/utils/configs/queries.py
@@ -14,11 +14,11 @@ from app.utils.settings.config import settings
 
 def c_config_query(config_definition_key: str, config_key: str, data: dict) -> tuple:
     """
-    Insert a new configuration definition in the internal table.
+    Insert a new configuration in the configuration table.
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     config_key: str
         The key for the configuration.
     data: dict
@@ -48,7 +48,7 @@ def c_config_query(config_definition_key: str, config_key: str, data: dict) -> t
 
 def d_config_query(config_definition_key: str, config_key: str) -> tuple:
     """
-    Delete a configuration from the configuration definition table.
+    Delete a configuration from the configuration table.
 
     -- Parameters
     config_definition_key: str

--- a/backend/app/utils/configs/utils.py
+++ b/backend/app/utils/configs/utils.py
@@ -20,11 +20,11 @@ data_store = DataStore()
 
 def c_config(config_definition_key: str, config_key: str, data: dict):
     """
-    Create a new configuration for the config definition.
+    Create a new configuration for the configuration definition.
 
     -- Parameters
     config_definition_key: str
-        The key for the configuration type.
+        The key for the configuration definition.
     config_key: str
         The key for the configuration.
     data: dict
@@ -43,7 +43,7 @@ def c_config(config_definition_key: str, config_key: str, data: dict):
 
 def d_config(config_definition_key: str, config_key: str):
     """
-    Delete a configuration from the config definition.
+    Delete a configuration from the configuration definition.
 
     -- Parameters
     config_definition_key: str


### PR DESCRIPTION
## Description

The  `config` and `config-definitions` API methods and it's associated utilities are now having appropriate docstrings.

   - The changes are made from `configuration-type` to `configuration-definition` in
   
      - `backend/app/utils/config_definition/utils.py`
      - `backend/app/utils/config_definition/queries.py`
      - `backend/app/utils/config_definition/validations.py`
      - `backend/app/utils/config/utils.py`
      - `backend/app/utils/config/queries.py`
      - `backend/app/api/v1/config_definitions.py`
      - `backend/app/api/v1/configs.py`

## Related Issue

- [X] Link to the related issue (if applicable) #32

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [X] Documentation

## Checklist

- [X] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] All tests pass



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated parameter descriptions for clarity across multiple functions related to configuration definitions.
	- Changed terminology from "configuration type" to "configuration definition" in various documentation strings.
	- Enhanced consistency in terminology within the documentation for improved user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->