### PR TITLE
feat(db): returning `rows_affected` while executing submit queries

### DIFF
--- a/backend/app/utils/config_definitions/utils.py
+++ b/backend/app/utils/config_definitions/utils.py
@@ -51,17 +51,17 @@ def c_config_definition(config_definition_key: str, json_schema: dict, indexes: 
     internal_query, internal_params = internal_c_definition_query(
         config_definition_key, json_schema, indexes
     )
-    data_store._execute_query(internal_query, internal_params)
+    data_store.execute_query(internal_query, internal_params)
 
     creation_query, creation_params = c_config_definition_query(config_definition_key)
-    data_store._execute_query(creation_query, creation_params)
+    data_store.execute_query(creation_query, creation_params)
 
     for index in indexes:
         index_query, index_params = c_index_query(config_definition_key, index)
-        data_store._execute_query(index_query, index_params)
+        data_store.execute_query(index_query, index_params)
 
     index_query, index_params = c_index_query(config_definition_key, index)
-    data_store._execute_query(index_query, index_params)
+    data_store.execute_query(index_query, index_params)
 
     return None
 
@@ -82,7 +82,7 @@ def r_config_definition(config_definition_key: str):
     validate_config_read(config_definition_key)
 
     query, params = r_config_definition_query(config_definition_key)
-    result = data_store._execute_query(query, params=params, mode="retrieve")
+    result = data_store.execute_query(query, params=params, mode="retrieve")["response"]
 
     if len(result) == 0 or result is None:
         raise ValueError("Configuration definition not found.")
@@ -110,22 +110,24 @@ def u_config_definition(config_definition_key: str, indexes: list):
     internal_query, internal_params = internal_u_definition_query(
         config_definition_key, indexes
     )
-    data_store._execute_query(internal_query, internal_params)
+    data_store.execute_query(internal_query, internal_params)
 
     list_query, list_params = l_index_query(config_definition_key)
 
-    result = data_store._execute_query(list_query, params=list_params, mode="retrieve")
+    result = data_store.execute_query(list_query, params=list_params, mode="retrieve")[
+        "response"
+    ]
     existing_indexes = [index["indexname"] for index in result]
 
     for index in indexes:
         if index not in existing_indexes:
             index_query, index_params = c_index_query(config_definition_key, index)
-            data_store._execute_query(index_query, index_params)
+            data_store.execute_query(index_query, index_params)
 
     for index in existing_indexes:
         if index not in indexes:
             index_query, index_params = d_index_query(config_definition_key, index)
-            data_store._execute_query(index_query, index_params)
+            data_store.execute_query(index_query, index_params)
 
     return None
 
@@ -145,10 +147,15 @@ def d_config_definition(config_definition_key: str):
     validate_config_delete(config_definition_key)
 
     internal_query, internal_params = internal_d_definition_query(config_definition_key)
-    data_store._execute_query(internal_query, internal_params)
+    rows_affected = data_store.execute_query(internal_query, internal_params)[
+        "rows_affected"
+    ]
+
+    if rows_affected == 0:
+        raise ValueError("Configuration definition not found.")
 
     delete_query, delete_params = d_config_definition_query(config_definition_key)
-    data_store._execute_query(delete_query, delete_params)
+    data_store.execute_query(delete_query, delete_params)
 
     return None
 
@@ -171,6 +178,6 @@ def l_config_definition(page: int = 1, page_size: int = 10):
     validate_list_params(page, page_size)
 
     query, params = l_config_definition_query(page, page_size)
-    result = data_store._execute_query(query, params=params, mode="retrieve")
+    result = data_store.execute_query(query, params=params, mode="retrieve")["response"]
 
     return result

--- a/backend/app/utils/configs/utils.py
+++ b/backend/app/utils/configs/utils.py
@@ -36,7 +36,7 @@ def c_config(config_definition_key: str, config_key: str, data: dict):
     creation_query, creation_params = c_config_query(
         config_definition_key, config_key, data
     )
-    data_store._execute_query(creation_query, creation_params)
+    data_store.execute_query(creation_query, creation_params)
 
     return None
 
@@ -55,6 +55,11 @@ def d_config(config_definition_key: str, config_key: str):
     validate_config_deletion(config_definition_key, config_key)
 
     deletion_query, deletion_params = d_config_query(config_definition_key, config_key)
-    data_store._execute_query(deletion_query, deletion_params)
+    rows_affected = data_store.execute_query(deletion_query, deletion_params)[
+        "rows_affected"
+    ]
+
+    if rows_affected == 0:
+        raise ValueError("Configuration not found.")
 
     return None

--- a/backend/app/utils/configs/validations.py
+++ b/backend/app/utils/configs/validations.py
@@ -86,6 +86,7 @@ def validate_config_deletion(config_definition_key: str, config_key: str) -> Non
     config_key: str
         The key for the configuration.
     """
+    r_config_definition(config_definition_key)
     validate_config_definition_key(config_definition_key)
     validate_config_key(config_key)
 

--- a/backend/tests/unit_tests/config/payloads/payload_extractor.py
+++ b/backend/tests/unit_tests/config/payloads/payload_extractor.py
@@ -44,4 +44,6 @@ def extract_payload_params(payload):
     data = payload.get("data")
     schema = payload.get("schema", {})
 
-    return (config_definition_key, config_key, data, schema)
+    return_value = payload.get("return_value")
+
+    return (config_definition_key, config_key, data, schema, return_value)

--- a/backend/tests/unit_tests/config/payloads/payloads.json
+++ b/backend/tests/unit_tests/config/payloads/payloads.json
@@ -63,19 +63,35 @@
     "delete": {
       "test_delete_w_key": {
         "config_key": "sample_config",
-        "config_definition_key": "sample_config_definition"
+        "config_definition_key": "sample_config_definition",
+        "return_value": {
+          "rows_affected": 1,
+          "response": [{}]
+        }
       },
       "test_delete_o_key": {
         "config_key": "",
-        "config_definition_key": "sample_config_definition"
+        "config_definition_key": "sample_config_definition",
+        "return_value": {
+          "rows_affected": 0,
+          "response": []
+        }
       },
       "test_delete_w_cd_key": {
         "config_key": "sample_config",
-        "config_definition_key": "sample_config_definition"
+        "config_definition_key": "sample_config_definition",
+        "return_value": {
+          "rows_affected": 1,
+          "response": [{}]
+        }
       },
       "test_delete_o_cd_key": {
         "config_key": "sample_config",
-        "config_definition_key": ""
+        "config_definition_key": "",
+        "return_value": {
+          "rows_affected": 0,
+          "response": []
+        }
       }
     },
     "list": {}

--- a/backend/tests/unit_tests/config/test_create.py
+++ b/backend/tests/unit_tests/config/test_create.py
@@ -6,7 +6,7 @@
 
 """
 
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -19,10 +19,6 @@ with patch("app.utils.data.data_source.connect") as mock_connect:
     from app.utils.configs.utils import (
         c_config,
     )
-
-from app.utils.configs.queries import (
-    c_config_query,
-)
 
 from tests.unit_tests.config.payloads.payload_extractor import (
     extract_payload_params,
@@ -52,7 +48,7 @@ class TestConfigCreate:
         """
         Helper function to run c_config_definition and handle assertions.
         """
-        (config_definition_key, config_key, data, schema) = extract_payload_params(
+        (config_definition_key, config_key, data, schema, _) = extract_payload_params(
             payload_extract
         )
 
@@ -68,7 +64,7 @@ class TestConfigCreate:
         mock_execute_query.assert_called_once()
 
     @patch("app.utils.configs.validations.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_w_schema(
         self, mock_execute_query, mock_r_config_definition, get_payload
     ):
@@ -84,7 +80,7 @@ class TestConfigCreate:
         )
 
     @patch("app.utils.configs.validations.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_o_schema(
         self, mock_execute_query, mock_r_config_definition, get_payload
     ):
@@ -100,7 +96,7 @@ class TestConfigCreate:
         )
 
     @patch("app.utils.configs.validations.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_n_schema(
         self, mock_execute_query, mock_r_config_definition, get_payload
     ):

--- a/backend/tests/unit_tests/config/test_delete.py
+++ b/backend/tests/unit_tests/config/test_delete.py
@@ -51,22 +51,29 @@ class TestConfigDelete:
         """
         Helper function to run d_config and handle assertions.
         """
-        (config_definition_key, config_key, _, _) = extract_payload_params(
-            payload_extract
-        )
+        (
+            config_definition_key,
+            config_key,
+            _,
+            _,
+            return_value,
+        ) = extract_payload_params(payload_extract)
 
-        delete_query, delete_params = d_config_query(config_definition_key, config_key)
+        mock_execute_query.return_value = return_value
 
         if expect_error:
             with pytest.raises(ValueError):
                 d_config(config_definition_key, config_key)
-                mock_execute_query.assert_not_called()
             return
 
-        d_config(config_definition_key, config_key)
-        mock_execute_query.assert_called_once()
+        deletion_query, deletion_params = d_config_query(
+            config_definition_key, config_key
+        )
 
-    @patch.object(DataStore, "_execute_query")
+        d_config(config_definition_key, config_key)
+        mock_execute_query.assert_any_call(deletion_query, deletion_params)
+
+    @patch.object(DataStore, "execute_query")
     def test_delete_w_key(self, mock_execute_query, get_payload):
         """
         Test the deletion of a configuration with a key.
@@ -74,7 +81,7 @@ class TestConfigDelete:
         payload_extract = get_payload["test_delete_w_key"]
         self._run_d_config(payload_extract, mock_execute_query)
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_delete_o_key(self, mock_execute_query, get_payload):
         """
         Test the deletion of a configuration without a key.
@@ -82,7 +89,7 @@ class TestConfigDelete:
         payload_extract = get_payload["test_delete_o_key"]
         self._run_d_config(payload_extract, mock_execute_query, expect_error=True)
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_delete_w_cd_key(self, mock_execute_query, get_payload):
         """
         Test the deletion of a configuration with a key and config definition key.
@@ -90,7 +97,7 @@ class TestConfigDelete:
         payload_extract = get_payload["test_delete_w_cd_key"]
         self._run_d_config(payload_extract, mock_execute_query)
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_delete_o_cd_key(self, mock_execute_query, get_payload):
         """
         Test the deletion of a configuration without a key and config definition key.

--- a/backend/tests/unit_tests/config_definition/payloads/payload_extractor.py
+++ b/backend/tests/unit_tests/config_definition/payloads/payload_extractor.py
@@ -47,4 +47,6 @@ def extract_payload_params(payload):
     page = payload.get("page")
     page_size = payload.get("page_size")
 
-    return (config_key, schema, index, indexes, page, page_size)
+    return_value = payload.get("return_value")
+
+    return (config_key, schema, index, indexes, page, page_size, return_value)

--- a/backend/tests/unit_tests/config_definition/payloads/payloads.json
+++ b/backend/tests/unit_tests/config_definition/payloads/payloads.json
@@ -64,7 +64,11 @@
     },
     "read": {
       "test_read_w_key": {
-        "config_key": "sample_config"
+        "config_key": "sample_config",
+        "return_value": {
+          "rows_affected": 0, 
+          "response": [{"json_schema": "{'type': 'object'}"}]
+        }
       },
       "test_read_o_key": {
         "config_key": ""
@@ -73,29 +77,87 @@
     "update": {
       "test_update_w_index": {
         "config_key": "sample_config",
-        "indexes": ["name"]
+        "schema": {
+          "json_schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string"
+              }
+            }
+          },
+          "index": ["date"]
+        },
+        "indexes": ["name"],
+        "return_value": {
+            "rows_affected": 0,
+            "response": [{"indexname": "date"}]
+        }
       },
       "test_update_d_index": {
         "config_key": "sample_config",
+        "schema": {
+          "json_schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string"
+              }
+            }
+          },
+          "indexes": ["date"]
+        },
         "indexes": ["name", "name"]
       },
       "test_update_n_index": {
         "config_key": "sample_config",
+        "schema": {
+          "json_schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string"
+              }
+            }
+          },
+          "indexes": ["date"]
+        },
         "indexes": ["dog"]
       }
     },
     "delete": {
       "test_delete_w_key": {
-        "config_key": "sample_config"
+        "config_key": "sample_config",
+        "return_value": {
+            "rows_affected": 1, 
+            "response": [{}]
+        }
       },
       "test_delete_o_key": {
-        "config_key": ""
+        "config_key": "",
+        "return_value": {
+            "rows_affected": 0, 
+            "response": []
+        }
       }
     },
     "list": {
       "test_list_w_params": {
         "page": 1,
-        "page_size": 10
+        "page_size": 10,
+        "return_value": {
+          "rows_affected": 1,
+          "response": [{}]
+        }
       },
       "test_list_n_page": {
         "page": -1,

--- a/backend/tests/unit_tests/config_definition/test_create.py
+++ b/backend/tests/unit_tests/config_definition/test_create.py
@@ -53,14 +53,9 @@ class TestConfigDefinitionCreate:
         """
         Helper function to run c_config_definition and handle assertions.
         """
-        (
-            config_key,
-            schema,
-            index,
-            indexes,
-            _,
-            _,
-        ) = extract_payload_params(payload_extract)
+        (config_key, schema, index, indexes, _, _, _) = extract_payload_params(
+            payload_extract
+        )
 
         if expect_error:
             with pytest.raises(ValueError):
@@ -79,7 +74,7 @@ class TestConfigDefinitionCreate:
         mock_execute_query.assert_any_call(internal_query, internal_params)
         mock_execute_query.assert_any_call(index_query, index_params)
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_w_schema(self, mock_execute_query, get_payload):
         """
         Test that the function creates a new configuration definition with a schema.
@@ -89,7 +84,7 @@ class TestConfigDefinitionCreate:
             payload_extract, mock_execute_query, expect_error=False
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_o_schema(self, mock_execute_query, get_payload):
         """
         Test that the function creates a new configuration definition without a schema.
@@ -99,7 +94,7 @@ class TestConfigDefinitionCreate:
             payload_extract, mock_execute_query, expect_error=False
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_n_schema(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception if the schema is invalid.
@@ -109,7 +104,7 @@ class TestConfigDefinitionCreate:
             payload_extract, mock_execute_query, expect_error=True
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_d_sindex(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception if the index are duplicated.
@@ -119,7 +114,7 @@ class TestConfigDefinitionCreate:
             payload_extract, mock_execute_query, expect_error=True
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_create_n_sindex(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception if the indexes are not in the schema.

--- a/backend/tests/unit_tests/config_definition/test_delete.py
+++ b/backend/tests/unit_tests/config_definition/test_delete.py
@@ -48,17 +48,11 @@ class TestConfigDefinitionDelete:
         """
         Helper function to run d_config_definition and handle assertions.
         """
-        (
-            config_key,
-            _,
-            _,
-            _,
-            _,
-            _,
-        ) = extract_payload_params(payload_extract)
+        (config_key, _, _, _, _, _, return_value) = extract_payload_params(
+            payload_extract
+        )
 
-        delete_query, delete_params = d_config_definition_query(config_key)
-        internal_query, internal_params = internal_d_definition_query(config_key)
+        mock_execute_query.return_value = return_value
 
         if expect_error:
             with pytest.raises(ValueError):
@@ -66,12 +60,15 @@ class TestConfigDefinitionDelete:
             mock_execute_query.assert_not_called()
             return
 
+        delete_query, delete_params = d_config_definition_query(config_key)
+        internal_query, internal_params = internal_d_definition_query(config_key)
+
         d_config_definition(config_key)
 
         mock_execute_query.assert_any_call(delete_query, delete_params)
         mock_execute_query.assert_any_call(internal_query, internal_params)
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_delete_w_key(self, mock_execute_query, get_payload):
         """
         Test that the function deletes a configuration definition with a valid key.
@@ -81,7 +78,7 @@ class TestConfigDefinitionDelete:
             payload_extract, mock_execute_query, expect_error=False
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_delete_o_key(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception when trying to delete with an empty key.

--- a/backend/tests/unit_tests/config_definition/test_list.py
+++ b/backend/tests/unit_tests/config_definition/test_list.py
@@ -52,6 +52,7 @@ class TestConfigDefinitionList:
             _,
             page_number,
             items_per_page,
+            return_value,
         ) = extract_payload_params(payload_extract)
 
         if expect_error:
@@ -60,16 +61,18 @@ class TestConfigDefinitionList:
             mock_execute_query.assert_not_called()
             return
 
+        mock_execute_query.return_value = return_value
         internal_query, internal_params = l_config_definition_query(
             page_number, items_per_page
         )
+
         l_config_definition(page_number, items_per_page)
 
         mock_execute_query.assert_called_once_with(
             internal_query, params=internal_params, mode="retrieve"
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_list_w_params(self, mock_execute_query, get_payload):
         """
         Test that the function lists configuration definitions with a valid page number and items per page.
@@ -79,7 +82,7 @@ class TestConfigDefinitionList:
             payload_extract, mock_execute_query, expect_error=False
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_list_n_page(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception when given an invalid page number.
@@ -89,7 +92,7 @@ class TestConfigDefinitionList:
             payload_extract, mock_execute_query, expect_error=True
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_list_n_nlimit(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception when given an invalid page size.
@@ -99,7 +102,7 @@ class TestConfigDefinitionList:
             payload_extract, mock_execute_query, expect_error=True
         )
 
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_list_n_plimit(self, mock_execute_query, get_payload):
         """
         Test that the function raises an exception when given an excessive page size.

--- a/backend/tests/unit_tests/config_definition/test_read.py
+++ b/backend/tests/unit_tests/config_definition/test_read.py
@@ -49,25 +49,25 @@ class TestConfigDefinitionRead:
             _,
             _,
             _,
+            return_value,
         ) = extract_payload_params(payload_extract)
 
         if expect_error:
             with pytest.raises(ValueError):
                 r_config_definition(config_key)
             mock_execute_query.assert_not_called()
-        else:
-            internal_query, internal_params = r_config_definition_query(config_key)
-            r_config_definition(config_key)
+            return
 
-            mock_execute_query.assert_called_once_with(
-                internal_query, params=internal_params, mode="retrieve"
-            )
+        mock_execute_query.return_value = return_value
+        internal_query, internal_params = r_config_definition_query(config_key)
 
-    @patch.object(
-        DataStore,
-        "_execute_query",
-        return_value=[{"json_schema": '{"type": "object"}'}],
-    )
+        r_config_definition(config_key)
+
+        mock_execute_query.assert_called_once_with(
+            internal_query, params=internal_params, mode="retrieve"
+        )
+
+    @patch.object(DataStore, "execute_query")
     def test_read_w_key(self, mock_execute_query, get_payload):
         """
         Test that the function retrieves a configuration definition with a given key.
@@ -77,11 +77,7 @@ class TestConfigDefinitionRead:
             payload_extract, mock_execute_query, expect_error=False
         )
 
-    @patch.object(
-        DataStore,
-        "_execute_query",
-        return_value=[{"json_schema": '{"type": "object"}'}],
-    )
+    @patch.object(DataStore, "execute_query")
     def test_read_o_key(self, mock_execute_query, get_payload):
         """
         Test that the function raises a ValueError if the config key is not given.

--- a/backend/tests/unit_tests/config_definition/test_update.py
+++ b/backend/tests/unit_tests/config_definition/test_update.py
@@ -55,11 +55,12 @@ class TestConfigDefinitionUpdate:
 
         (
             config_key,
-            _,
+            schema,
             _,
             updated_indexes_list,
             _,
             _,
+            return_value,
         ) = extract_payload_params(payload_extract)
 
         if expect_error:
@@ -68,13 +69,7 @@ class TestConfigDefinitionUpdate:
             mock_execute_query.assert_not_called()
             return
 
-        mock_r_config_definition.return_value = {
-            "json_schema": {
-                "type": "object",
-                "properties": {"name": {"type": "string"}, "date": {"type": "string"}},
-            },
-            "indexes": ["date"],
-        }
+        mock_r_config_definition.return_value = schema
 
         internal_query, internal_params = internal_u_definition_query(
             config_key, updated_indexes_list
@@ -83,16 +78,7 @@ class TestConfigDefinitionUpdate:
         index_creation_query, index_creation_params = c_index_query(config_key, "name")
         index_deletion_query, index_deletion_params = d_index_query(config_key, "date")
 
-        def side_effect(query, params=None, mode=None):
-            if (
-                query == index_list_query
-                and params == index_list_params
-                and mode == "retrieve"
-            ):
-                return [{"indexname": "date"}]
-            return []
-
-        mock_execute_query.side_effect = side_effect
+        mock_execute_query.return_value = return_value
 
         u_config_definition(config_key, updated_indexes_list)
 
@@ -106,7 +92,7 @@ class TestConfigDefinitionUpdate:
         mock_execute_query.assert_any_call(internal_query, internal_params)
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_update_w_index(
         self, mock_execute_query, mock_r_config_definition, get_payload
     ):
@@ -123,7 +109,7 @@ class TestConfigDefinitionUpdate:
         )
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_update_d_index(
         self, mock_execute_query, mock_r_config_definition, get_payload
     ):
@@ -140,7 +126,7 @@ class TestConfigDefinitionUpdate:
         )
 
     @patch("app.utils.config_definitions.utils.r_config_definition")
-    @patch.object(DataStore, "_execute_query")
+    @patch.object(DataStore, "execute_query")
     def test_update_n_index(self, mock_execute_query, mock_r_config_definition):
         """
         Test that the function raises an exception if the secondary index is not found.


### PR DESCRIPTION
## Description

- Returning `rows_affected` when calling `execute_query` is essential and useful in many places.
    - During a recent observation during manual testing, deletion of configs or config definitions without the appropriate ID returned successful deletion responses, as well as a `200` status code.
    - Added a patch for the above issue by including the `rows_affected` in the `execute_query()` return values, and adding a condition after deletion utility to check it's value to confirm deletion took place.
    - Changed `DataStore` class method `execute_query` to public, since it's being called outside of the class instances.
    - Moved all instances of hard-coded payloads in the test `.py` files to the `JSON` payloads file.
    - Modified all dependent utilities and tests to work with the changes described.

## Related Issue

- [x] Link to the related issue (if applicable) #34 #35 #37 

## Type of Change

- [x] Bugfix
- [x] New Feature

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error handling for configuration deletion to raise an error if no rows are affected.
	- Updated payload extraction to include additional return values for improved context in test cases.

- **Bug Fixes**
	- Improved query execution method for better clarity and consistency across various functions.

- **Tests**
	- Updated unit tests to mock the new public `execute_query` method instead of the private `_execute_query` method, ensuring accurate testing of query execution.
	- Adjusted test cases to reflect changes in return values and improve validation of outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->