### PR TITLE
fix(build): dynamic versioning configuration for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd backend
           pip install poetry
-          poetry install
+          poetry install --no-root
           poetry run pytest tests/unit_tests/ --disable-warnings
   
   integration-tests:
@@ -75,7 +75,7 @@ jobs:
         run: |
           cd backend
           pip install poetry
-          poetry install
+          poetry install --no-root
           poetry run pytest tests/integration_tests/ --disable-warnings
 
   library-tests:
@@ -107,7 +107,7 @@ jobs:
         run: |
           cd backend
           pip install poetry
-          poetry install
+          poetry install --no-root
           nohup poetry run uvicorn main:app --host 0.0.0.0 --port 8000 &
 
       - name: Wait for Server to Start

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - uses: actions/setup-python@v3
       with:
         python-version: 3.12
@@ -24,11 +27,13 @@ jobs:
     - name: Install Dependencies
       run: |
         cd library
+        poetry self add "poetry-dynamic-versioning[plugin]"
         poetry install
 
     - name: Build the Package
       run: |
         cd library
+        echo "Version: $(poetry version)"
         poetry build
 
     - name: Publish to PyPI


### PR DESCRIPTION
## Description

- While launching a GitHub Release, with a brand new tag, it is expected by `pypi-publish.yaml` CI to build and publish a version for `tartarus-lib` based on the tag it was triggered with.
- But it was observed when the release `0.1.1` was published, `tartarus-lib`'s push in PyPi corresponded to `0.0.0` 
- This suggested a problem with the CI file. It was observed that the `dynamic-versioning` package was not added before build, thus causing the build to follow the default version provided in the `pyproject.toml` - `0.0.0`.


## Related Issue

- [x] Link to the related issue #61 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation

## Checklist

- [x] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [x] All tests pass



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for package publishing
	- Enhanced Poetry dependency management configuration
	- Added version information display during package build process
	- Minor formatting adjustment in CI workflow for improved readability
	- Modified CI jobs to improve dependency installation process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->