### PR TITLE
feat(app): enabled cross-origin resource access for tartarus

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@
 import logging
 import logging.config
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.utils.exceptions.errors import APIError
 from app.utils.exceptions.logger import get_log_config
@@ -25,6 +26,13 @@ app = FastAPI(
 logging.config.dictConfig(get_log_config())
 
 app.add_exception_handler(APIError, api_error_handler)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.add_middleware(ErrorHandlingMiddleware)
 app.include_router(api_router_v1, prefix="/api/v1")
 


### PR DESCRIPTION
## Description

While trying out the API Playground in mintlify, it was observed that the browser-client was not able to hit the localhost (locally run uvicorn server). Hence a minor addition have been made to the middlewares being used.

- Setting `'*'` for access points in the CORS Middleware for FastAPI.
- In the future, we can also implement whitelisting of domains/IP based on requests from contributors/ users.

## Related Issue

- [x] Link to the related issue #65 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation

## Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Cross-Origin Resource Sharing (CORS) support to enable web applications to make cross-origin requests to the backend API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->